### PR TITLE
Remove note for excluding VPN traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # balenaOS device proxy tunnel
-> [redirect](https://www.balena.io/docs/reference/OS/network/2.x/#connecting-behind-a-proxy) all TCP traffic (except for VPN) from balenaOS devices via an SSH tunnel to a SOCKS5 proxy, running on DigitalOcean or AWS/EC2
+> [redirect](https://www.balena.io/docs/reference/OS/network/2.x/#connecting-behind-a-proxy) all TCP traffic from balenaOS devices via an SSH tunnel to a SOCKS5 proxy, running on DigitalOcean or AWS/EC2
 > 
 
 [![](https://balena.io/deploy.svg)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/balena-labs-projects/proxy-tunnel)

--- a/balena.yml
+++ b/balena.yml
@@ -1,7 +1,7 @@
 name: proxy-tunnel
 type: sw.application
 description: >-
-  Redirect all TCP traffic (except for VPN) from balenaOS devices via an SSH
+  Redirect all TCP traffic from balenaOS devices via an SSH
   tunnel to a SOCKS5 proxy, running on DigitalOcean or AWS/EC2.
 assets:
   repository:


### PR DESCRIPTION
The OpenVPN traffic of balenaOS uses TCP on port 443 and redsocks redirects that through the proxy as well.
